### PR TITLE
Change 'GPU' TO 'CPU' in quantize() docs

### DIFF
--- a/aitextgen/aitextgen.py
+++ b/aitextgen/aitextgen.py
@@ -642,7 +642,7 @@ class aitextgen:
     def quantize(self):
         """
         Quantizes the model, which gives it a generation performance boost.
-        Should only be used to generate on a supported GPU.
+        Should only be used to generate on a supported CPU.
 
         Currently only the lm_head layer is quantized:
         https://github.com/pytorch/pytorch/issues/34074


### PR DESCRIPTION
I noticed the quantize() method has an assertion checking that the current device is CPU and an error message specifying CPU only aswell, docs mentioned GPU only which I am assuming is a typo. 