### PR TITLE
increases possible size of csv fields

### DIFF
--- a/aitextgen/TokenDataset.py
+++ b/aitextgen/TokenDataset.py
@@ -10,6 +10,9 @@ from pkg_resources import resource_filename
 import itertools
 from tqdm.auto import tqdm
 import numpy as np
+import sys
+
+csv.field_size_limit(sys.maxsize)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
When dealing with large blocks of text in the recommended manner the default csv parser might not handle the amount of text passed
"_csv.Error: field larger than field limit (131072)"
increasing the limit will allow the text to be processed