### PR TITLE
Add n_generate and save_gdrive variables to ATGProgressCallback

### DIFF
--- a/aitextgen/aitextgen.py
+++ b/aitextgen/aitextgen.py
@@ -662,7 +662,9 @@ class aitextgen:
                 progress_bar_refresh_rate,
                 save_every,
                 generate_every,
+                n_generate,
                 output_dir,
+                save_gdrive,
                 avg_loss_smoothing,
                 is_gpu_used,
             )

--- a/aitextgen/train_callback.py
+++ b/aitextgen/train_callback.py
@@ -18,7 +18,9 @@ class ATGProgressCallback(TrainerCallback):
         refresh_rate,
         save_every,
         generate_every,
+        n_generate,
         output_dir,
+        save_gdrive,
         avg_loss_smoothing,
         is_gpu_used,
     ):
@@ -29,7 +31,9 @@ class ATGProgressCallback(TrainerCallback):
         self.refresh_rate = refresh_rate
         self.save_every = save_every
         self.generate_every = generate_every
+        self.n_generate = n_generate
         self.output_dir = output_dir
+        self.save_gdrive = save_gdrive
         self.smoothing = avg_loss_smoothing
         self.gpu = is_gpu_used
         self.steps = 0


### PR DESCRIPTION
I started trying to use the `trainer` branch of aitextgen, and found that it crashed when attempting to either save the model or generate texts from it while training, due to the `n_generate` and `save_gdrive` variables not having been created. This pull request adds those variables as members of `ATGProgressCallback` so that training can complete.