### PR TITLE
Declare `amp_backend` parameter for Torch Lightning

### DIFF
--- a/aitextgen/aitextgen.py
+++ b/aitextgen/aitextgen.py
@@ -734,6 +734,7 @@ class aitextgen:
         if fp16:
             train_params["precision"] = 16 if fp16 else 32
             train_params["amp_level"] = fp16_opt_level
+            train_params["amp_backend"] = "apex"
 
         if tpu_cores > 0:
             train_params["tpu_cores"] = tpu_cores


### PR DESCRIPTION
Addressing #180 

- lightning requires explicitly setting the AMP backend
- the AMP level is only set when utilizing fp16 floats, so this sets the amp backend under the same conditions