### PR TITLE
Remove space from "My Drive" folder name

### DIFF
--- a/aitextgen/aitextgen.py
+++ b/aitextgen/aitextgen.py
@@ -759,7 +759,7 @@ class aitextgen:
             for pt_file in ["pytorch_model.bin", "config.json"]:
                 shutil.copyfile(
                     os.path.join(output_dir, pt_file),
-                    os.path.join("/content/drive/My Drive/", run_id, pt_file),
+                    os.path.join("/content/drive/MyDrive/", run_id, pt_file),
                 )
 
         if seed:

--- a/aitextgen/colab.py
+++ b/aitextgen/colab.py
@@ -27,9 +27,9 @@ def copy_file_to_gdrive(file_path, to_folder=None):
     is_mounted()
 
     if to_folder:
-        dest_path = os.path.join("/content/drive/My Drive/", to_folder, file_path)
+        dest_path = os.path.join("/content/drive/MyDrive/", to_folder, file_path)
     else:
-        dest_path = os.path.join("/content/drive/My Drive/", file_path)
+        dest_path = os.path.join("/content/drive/MyDrive/", file_path)
 
     shutil.copyfile(file_path, dest_path)
 
@@ -39,9 +39,9 @@ def copy_file_from_gdrive(file_path, from_folder=None):
     is_mounted()
 
     if from_folder:
-        source_path = os.path.join("/content/drive/My Drive/", from_folder, file_path)
+        source_path = os.path.join("/content/drive/MyDrive/", from_folder, file_path)
     else:
-        source_path = os.path.join("/content/drive/My Drive/", file_path)
+        source_path = os.path.join("/content/drive/MyDrive/", file_path)
 
     shutil.copyfile(source_path, file_path)
 
@@ -50,7 +50,7 @@ def create_gdrive_folder(folder_name):
     """Creates a folder in a mounted Google Drive."""
     is_mounted()
 
-    folder_path = os.path.join("/content/drive/My Drive/", folder_name)
+    folder_path = os.path.join("/content/drive/MyDrive/", folder_name)
 
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)

--- a/aitextgen/train.py
+++ b/aitextgen/train.py
@@ -251,7 +251,7 @@ class ATGProgressBar(ProgressBarBase):
             for pt_file in ["pytorch_model.bin", "config.json"]:
                 shutil.copyfile(
                     os.path.join(self.output_dir, pt_file),
-                    os.path.join("/content/drive/My Drive/", self.run_id, pt_file),
+                    os.path.join("/content/drive/MyDrive/", self.run_id, pt_file),
                 )
 
     def average_loss(self, current_loss, prev_avg_loss, smoothing):

--- a/docs/save-model.md
+++ b/docs/save-model.md
@@ -29,7 +29,7 @@ from aitextgen.colab import mount_gdrive, copy_file_to_gdrive
 mount_gdrive()
 ```
 
-You'll be asked for an auth code; input it and press enter, and a `My Drive` folder will appear in Colab Files view.
+You'll be asked for an auth code; input it and press enter, and a `MyDrive` folder will appear in Colab Files view.
 
 You can drag and drop the model files into the Google Drive, or use `copy_file_to_gdrive` to copy them programmatically.
 


### PR DESCRIPTION
Google has updated Colab, and the My Drive folder no longer has a space in the name.

Fixes #155 and #163.