### PR TITLE
update pytorch-lightning requirement to >= 1.8.0

### DIFF
--- a/aitextgen/train.py
+++ b/aitextgen/train.py
@@ -115,7 +115,7 @@ class ATGProgressBar(ProgressBarBase):
         self.progress_bar_refresh_rate = progress_bar_refresh_rate
         self.train_transformers_only = train_transformers_only
         self.num_layers_freeze = num_layers_freeze
-        
+
     @property
     def save_every_check(self):
         return self.save_every > 0 and self.steps % self.save_every == 0
@@ -141,15 +141,15 @@ class ATGProgressBar(ProgressBarBase):
     def on_train_end(self, trainer, pl_module):
         self.main_progress_bar.close()
         self.unfreeze_layers(pl_module)
-        
+
     def get_metrics(self, trainer, pl_module):
         # don't show the version number
         items = super().get_metrics(trainer, pl_module)
         items.pop("v_num", None)
         return items
 
-    def on_batch_end(self, trainer, pl_module):
-        super().on_batch_end(trainer, pl_module)
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
 
         # clean up the GPU cache used for the benchmark
         # https://discuss.pytorch.org/t/about-torch-cuda-empty-cache/34232/4
@@ -186,7 +186,7 @@ class ATGProgressBar(ProgressBarBase):
                 desc += f" — GPU Mem: {gpu_memory} MB"
             self.main_progress_bar.update(self.progress_bar_refresh_rate)
             self.main_progress_bar.set_description(desc)
-        
+
         if TPUAccelerator.is_available() and self.save_every_check:
             did_unfreeze = False
             if self.enabled:
@@ -195,7 +195,7 @@ class ATGProgressBar(ProgressBarBase):
             self.save_pytorch_model(trainer, pl_module, tpu=True)
             if did_unfreeze:
                 self.freeze_layers(pl_module)
-        
+
         if self.enabled:
             did_unfreeze = False
             if not TPUAccelerator.is_available() and self.save_every_check:
@@ -243,13 +243,14 @@ class ATGProgressBar(ProgressBarBase):
         self.main_progress_bar.write("=" * 10)
 
     def save_pytorch_model(self, trainer, pl_module, tpu=False):
-        
+
         if self.enabled:
             self.main_progress_bar.write(
                 f"\033[1m{self.steps:,} steps reached: saving model to /{self.output_dir}\033[0m"
             )
         if tpu:
             import torch_xla.core.xla_model as xm
+
             pl_module.model.save_pretrained(self.output_dir, save_function=xm.save)
         else:
             pl_module.model.save_pretrained(self.output_dir)

--- a/aitextgen/train.py
+++ b/aitextgen/train.py
@@ -11,7 +11,7 @@ from transformers import get_linear_schedule_with_warmup
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks.progress import ProgressBarBase
-from pytorch_lightning.utilities import _TPU_AVAILABLE
+from pytorch_lightning.accelerators import TPUAccelerator
 
 
 class ATGTransformer(pl.LightningModule):
@@ -187,7 +187,7 @@ class ATGProgressBar(ProgressBarBase):
             self.main_progress_bar.update(self.progress_bar_refresh_rate)
             self.main_progress_bar.set_description(desc)
         
-        if _TPU_AVAILABLE and self.save_every_check:
+        if TPUAccelerator.is_available() and self.save_every_check:
             did_unfreeze = False
             if self.enabled:
                 self.unfreeze_layers(pl_module)
@@ -198,7 +198,7 @@ class ATGProgressBar(ProgressBarBase):
         
         if self.enabled:
             did_unfreeze = False
-            if not _TPU_AVAILABLE and self.save_every_check:
+            if not TPUAccelerator.is_available() and self.save_every_check:
                 self.unfreeze_layers(pl_module)
                 self.save_pytorch_model(trainer, pl_module)
                 did_unfreeze = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 transformers>=4.5.1
 fire>=0.3.0
-pytorch-lightning>=1.3.1
+pytorch-lightning>=1.8.0
 torch>=1.6.0


### PR DESCRIPTION
pytorch_lightning removed this variable in commit https://github.com/Lightning-AI/lightning/commit/7ef87464ddd740f8af8388bd95130066c65874da  part of https://github.com/Lightning-AI/lightning/pull/14550, which seems to have gone out in lightning 1.8.0.

- replace _TPU_AVAILABLE with TPUAccelerator.is_available, which seems to be what the above referenced commit uses in its place
- fix updated callback name `on_batch_end` -> `on_train_batch_end`
- update pytorch-lightning req in requirements.txt

Without the change in place, I get:

```
$ python -c "from aitextgen.train import ATGTransformer"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/llimllib/.venv/lib/python3.10/site-packages/aitextgen/__init__.py", line 1, in <module>
    from .aitextgen import aitextgen  # noqa
  File "/Users/llimllib/.venv/lib/python3.10/site-packages/aitextgen/aitextgen.py", line 31, in <module>
    from .train import ATGProgressBar, ATGTransformer
  File "/Users/llimllib/.venv/lib/python3.10/site-packages/aitextgen/train.py", line 14, in <module>
    from pytorch_lightning.utilities import _TPU_AVAILABLE
ImportError: cannot import name '_TPU_AVAILABLE' from 'pytorch_lightning.utilities' (/Users/llimllib/.venv/lib/python3.10/site-packages/pytorch_lightning/utilities/__init__.py)
```

With it in place, I get no output as expected

```
python -c "from aitextgen.train import ATGTransformer"
```

I was also able to use the example colab notebook with this branch, which I was not able to using the published version of aitextgen

fixes #200 