### PR TITLE
Common Imports Fix and Readme Update to fix RuntimeError in trainer.fit()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ test_notebooks/
 .vscode/settings.json
 /site
 .DS_Store
+
+/test
+/trained_model
+aitextgen.tokenizer.json

--- a/README.md
+++ b/README.md
@@ -62,39 +62,44 @@ from aitextgen.tokenizers import train_tokenizer
 from aitextgen.utils import GPT2ConfigCPU
 from aitextgen import aitextgen
 
-# The name of the downloaded Shakespeare text for training
-file_name = "input.txt"
-
-# Train a custom BPE Tokenizer on the downloaded text
-# This will save one file: `aitextgen.tokenizer.json`, which contains the
-# information needed to rebuild the tokenizer.
-train_tokenizer(file_name)
-tokenizer_file = "aitextgen.tokenizer.json"
-
-# GPT2ConfigCPU is a mini variant of GPT-2 optimized for CPU-training
-# e.g. the # of input tokens here is 64 vs. 1024 for base GPT-2.
-config = GPT2ConfigCPU()
-
-# Instantiate aitextgen using the created tokenizer and config
-ai = aitextgen(tokenizer_file=tokenizer_file, config=config)
-
-# You can build datasets for training by creating TokenDatasets,
-# which automatically processes the dataset with the appropriate size.
-data = TokenDataset(file_name, tokenizer_file=tokenizer_file, block_size=64)
-
-# Train the model! It will save pytorch_model.bin periodically and after completion to the `trained_model` folder.
-# On a 2020 8-core iMac, this took ~25 minutes to run.
-ai.train(data, batch_size=8, num_steps=50000, generate_every=5000, save_every=5000)
-
-# Generate text from it!
-ai.generate(10, prompt="ROMEO:")
-
-# With your trained model, you can reload the model at any time by
-# providing the folder containing the pytorch_model.bin model weights + the config, and providing the tokenizer.
-ai2 = aitextgen(model_folder="trained_model",
-                tokenizer_file="aitextgen.tokenizer.json")
-
-ai2.generate(10, prompt="ROMEO:")
+# Your code needs to be wrapped inside a main function, 
+# as otherwise multiple child processes from pytorch_lightning cannot be spawned
+def main():
+  # The name of the downloaded Shakespeare text for training
+  file_name = "input.txt"
+  
+  # Train a custom BPE Tokenizer on the downloaded text
+  # This will save one file: `aitextgen.tokenizer.json`, which contains the
+  # information needed to rebuild the tokenizer.
+  train_tokenizer(file_name)
+  tokenizer_file = "aitextgen.tokenizer.json"
+  
+  # GPT2ConfigCPU is a mini variant of GPT-2 optimized for CPU-training
+  # e.g. the # of input tokens here is 64 vs. 1024 for base GPT-2.
+  config = GPT2ConfigCPU()
+  
+  # Instantiate aitextgen using the created tokenizer and config
+  ai = aitextgen(tokenizer_file=tokenizer_file, config=config)
+  
+  # You can build datasets for training by creating TokenDatasets,
+  # which automatically processes the dataset with the appropriate size.
+  data = TokenDataset(file_name, tokenizer_file=tokenizer_file, block_size=64)
+  
+  # Train the model! It will save pytorch_model.bin periodically and after completion to the `trained_model` folder.
+  # On a 2020 8-core iMac, this took ~25 minutes to run.
+  ai.train(data, batch_size=8, num_steps=50000, generate_every=5000, save_every=5000)
+  
+  # Generate text from it!
+  ai.generate(10, prompt="ROMEO:")
+  
+  # With your trained model, you can reload the model at any time by
+  # providing the folder containing the pytorch_model.bin model weights + the config, and providing the tokenizer.
+  ai2 = aitextgen(model_folder="trained_model",
+                  tokenizer_file="aitextgen.tokenizer.json")
+  
+  ai2.generate(10, prompt="ROMEO:")
+if __name__ == "__main__":
+  main()
 ```
 
 Want to run aitextgen and finetune GPT-2? Use the Colab notebooks in the Demos section, or [follow the documentation](https://docs.aitextgen.io/) to get more information and learn some helpful tips!

--- a/aitextgen/aitextgen.py
+++ b/aitextgen/aitextgen.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Union
 import pytorch_lightning as pl
 import torch
 from pkg_resources import resource_filename
-# from pytorch_lightning.plugins import DeepSpeedPlugin
+from pytorch_lightning.plugins import DeepSpeedPrecisionPlugin
 from tqdm.auto import trange
 from transformers import (
     AutoConfig,
@@ -698,7 +698,7 @@ class aitextgen:
         # use the DeepSpeed plugin if installed and specified
         deepspeed_plugin = None
         if is_gpu_used and use_deepspeed:
-            deepspeed_plugin = DeepSpeedPlugin()
+            deepspeed_plugin = DeepSpeedPrecisionPlugin()
             logger.info("Using DeepSpeed training.")
             if not fp16:
                 logger.info("Setting FP16 to True for DeepSpeed ZeRO Training.")

--- a/aitextgen/aitextgen.py
+++ b/aitextgen/aitextgen.py
@@ -698,7 +698,7 @@ class aitextgen:
         # use the DeepSpeed plugin if installed and specified
         deepspeed_plugin = None
         if is_gpu_used and use_deepspeed:
-            deepspeed_plugin = DeepSpeedPrecisionPlugin()
+            deepspeed_plugin = DeepSpeedPrecisionPlugin("16-mixed" if fp16 else "32-true")
             logger.info("Using DeepSpeed training.")
             if not fp16:
                 logger.info("Setting FP16 to True for DeepSpeed ZeRO Training.")
@@ -706,7 +706,7 @@ class aitextgen:
 
         train_params = dict(
             accumulate_grad_batches=gradient_accumulation_steps,
-            gpus=n_gpu,
+            num_nodes=n_gpu,
             max_steps=num_steps,
             gradient_clip_val=max_grad_norm,
             enable_checkpointing=False, #checkpoint_callback deprecated in pytorch_lighning v1.7
@@ -737,7 +737,7 @@ class aitextgen:
 
         if tpu_cores > 0:
             train_params["tpu_cores"] = tpu_cores
-            train_params["gpus"] = 0
+            train_params["num_nodes"] = 0
             n_gpu = 0
 
         # benchmark gives a boost for GPUs if input size is constant,

--- a/aitextgen/train.py
+++ b/aitextgen/train.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from transformers import get_linear_schedule_with_warmup
 
 import pytorch_lightning as pl
-from pytorch_lightning.callbacks.progress import ProgressBarBase
+from pytorch_lightning.callbacks.progress.progress_bar import ProgressBar
 from pytorch_lightning.accelerators import TPUAccelerator
 
 
@@ -83,7 +83,7 @@ class ATGTransformer(pl.LightningModule):
         return [optimizer], [scheduler]
 
 
-class ATGProgressBar(ProgressBarBase):
+class ATGProgressBar(ProgressBar):
     """A variant progress bar that works off of steps and prints periodically."""
 
     def __init__(

--- a/aitextgen/train.py
+++ b/aitextgen/train.py
@@ -156,8 +156,8 @@ class ATGProgressBar(ProgressBar):
         if self.steps == 0 and self.gpu:
             torch.cuda.empty_cache()
 
-        metrics = self.get_metrics(trainer, pl_module)
-        current_loss = float(metrics["loss"])
+        #metrics = self.get_metrics(trainer, pl_module)
+        current_loss = float(outputs["loss"])
         self.steps += 1
         avg_loss = 0
         if current_loss == current_loss:  # don't add if current_loss is NaN

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fire~=0.6.0
+fire~=0.5.0
 pytorch-lightning~=2.0.0
 transformers~=4.26.0
 torch~=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.5.1
-fire>=0.3.0
-pytorch-lightning>=1.8.0
-torch>=1.6.0
+fire~=0.6.0
+pytorch-lightning~=2.0.0
+transformers~=4.26.0
+torch~=1.13.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     python_requires=">=3.6",
     include_package_data=True,
     install_requires=[
-        "fire~=0.6.0",
+        "fire~=0.5.0",
         "pytorch-lightning~=2.0.0",
         "transformers~=4.26.0",
         "torch~=1.13.0",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="aitextgen",
     packages=["aitextgen"],  # this must be the same as the name above
-    version="0.6.0",
+    version="0.6.1",
     description="A robust Python tool for text-based AI training and generation using GPT-2.",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
@@ -17,9 +17,10 @@ setup(
     python_requires=">=3.6",
     include_package_data=True,
     install_requires=[
-        "transformers>=4.5.1",
-        "fire>=0.3.0",
-        "pytorch-lightning>=1.7.0",
-        "torch>=1.6.0",
+        "fire~=0.5.0",
+        "pytorch-lightning~=2.0.0",
+        "transformers~=4.26.0",
+        "torch~=1.13.0",
+        ,
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,9 @@ setup(
     python_requires=">=3.6",
     include_package_data=True,
     install_requires=[
-        "fire~=0.5.0",
+        "fire~=0.6.0",
         "pytorch-lightning~=2.0.0",
         "transformers~=4.26.0",
         "torch~=1.13.0",
-        ,
     ],
 )


### PR DESCRIPTION
Running example code with current package creates following errors:

- `cannot import name 'DeepSpeedPlugin' from 'pytorch_lightning.plugins` - `aitextgen.py` line 14
- `cannot import name 'ProgressBarBase' from 'pytorch_lightning.callbacks.progress` - `train.py` line 13
- `cannot import name '_TPU_AVAILABLE' from 'pytorch_lightning.utilities` - `train.py` line 14 - fixed in #202 
- `Runtime Error: An attempt has been made to start a new process before the current process has finished its bootstrapping phase.` - `aitextgen.py` line 752

The Runtime error suggests wrapping the user code in a main function as hinted here https://discuss.pytorch.org/t/runtimeerror-an-attempt-has-been-made-to-start-a-new-process-before-the-current-process-has-finished-its-bootstrapping-phase/145462

But I cannot confirm if this fixes the issue as the current code does not progress at all (Might also because ProgressBar is not the correct replacement for ProgressBarBase.

Would love to have your input if theses changes actually work!