### PR TITLE
Change 'ProgressBarBase' to 'ProgressBar' so it works on the (currently) latest PyTorch Lightning version

### DIFF
--- a/aitextgen/train.py
+++ b/aitextgen/train.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from transformers import get_linear_schedule_with_warmup
 
 import pytorch_lightning as pl
-from pytorch_lightning.callbacks.progress import ProgressBarBase
+from pytorch_lightning.callbacks import ProgressBar
 from pytorch_lightning.accelerators import TPUAccelerator
 
 
@@ -83,7 +83,7 @@ class ATGTransformer(pl.LightningModule):
         return [optimizer], [scheduler]
 
 
-class ATGProgressBar(ProgressBarBase):
+class ATGProgressBar(ProgressBar):
     """A variant progress bar that works off of steps and prints periodically."""
 
     def __init__(


### PR DESCRIPTION
I changed 'ProgressBarBase' to 'ProgressBar' because it changed in a PyTorch Lightning update. Based on their documentation, it appears it was changed after version 1.9.5, but I'm not positive. I do know that it was changed, so this should now work with the latest version of PyTorch Lightning at the time of writing.