### PR TITLE
Add support for Apple MPS GPU

### DIFF
--- a/aitextgen/aitextgen.py
+++ b/aitextgen/aitextgen.py
@@ -90,6 +90,7 @@ class aitextgen:
         cache_dir: str = "aitextgen",
         tf_gpt2: str = None,
         to_gpu: bool = False,
+        to_gpu_mps: bool = False,
         to_fp16: bool = False,
         verbose: bool = False,
         gradient_checkpointing: bool = False,
@@ -840,6 +841,15 @@ class aitextgen:
         assert torch.cuda.is_available(), "CUDA is not installed."
 
         self.model.to(torch.device("cuda", index))
+
+
+    def to_gpu_mps(self, index: int = 0) -> None:
+        """Moves the model to the specified GPU."""
+
+        assert torch.backends.mps.is_available(), "MPS is not installed."
+
+        self.model.to(torch.device("mps", index))
+
 
     def to_cpu(self, index: int = 0) -> None:
         """Moves the model to the specified CPU."""


### PR DESCRIPTION
This adds support for Apple MPS GPUs (Apple Silicon).  It adds a new function called to_gpu_mps, modelled on the to_gpu function.  A default parameter (__init__) is set to False.

It is based on the guidance below from Apple (see the 'verify' section): https://developer.apple.com/metal/pytorch/

I have not been able to test this because it connects onto Google Collab and other files I do not have.